### PR TITLE
Fix to stop the radar from getting stuck on screen.

### DIFF
--- a/ext/Client/__init__.lua
+++ b/ext/Client/__init__.lua
@@ -107,6 +107,7 @@ function MedicRadarClient:OnPostFrameUpdate(p_Delta)
 
 	-- Only continue if the local player is in man down state
 	if s_LocalPlayer == nil or s_LocalPlayer.corpse == nil then
+		self:ClearUI()
 		return
 	end
 


### PR DESCRIPTION
Just a simple fix to get the radar to clear itself if the player respawns before the revive timer is up.